### PR TITLE
Enable Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>celo-org/.github:renovate-config"]
+}


### PR DESCRIPTION
Enable Renovate instead of Dependabot for dependency management.
See https://github.com/celo-org/celo-labs/discussions/1051.